### PR TITLE
Issue 6

### DIFF
--- a/Components/CustomDrawerContent.jsx
+++ b/Components/CustomDrawerContent.jsx
@@ -1,6 +1,15 @@
 import React, { useState } from "react";
 import { DrawerContentScrollView, DrawerItemList, DrawerItem } from "@react-navigation/drawer";
 import { useNavigation } from "@react-navigation/native";
+import { ScrollView, StyleSheet, Text, View, Image } from "react-native";
+import { ImageBackground } from "react-native-web";
+import { Button } from 'react-native-paper';
+import demoIcon from "../assets/images/adaptive-icon.png";
+
+// dummy variables to be replaced by redux API retrieval
+const username = "OliveTree12"
+const accountTypeRetrieved = "propertyOwner"; 
+
 export default function CustomDrawerContent(props) {
   const navigation = useNavigation();
   const [active, setActive] = useState(0);
@@ -10,14 +19,139 @@ export default function CustomDrawerContent(props) {
     navigation.navigate(link);
   };
 
+  const accounts = [
+    {type: "tenant", colors: "#f83e7d", 
+      label: [
+        "My Account", 
+        "Favourites", 
+        "Payments", 
+        "Settings", 
+        "Help", 
+        "Blogs"
+      ], 
+      onClick: [
+        "myaccount", 
+        "favourites", 
+        "payments", 
+        "settings", 
+        "help", 
+        "blogs"
+      ]
+    },
+    {type: "propertyOwnerFemale", colors: "#0046F1", 
+      label: [
+        "My Account", 
+        "Event",
+        "Listings",
+        "Payments", 
+        "Settings", 
+        "Help", 
+        "Blogs"
+      ], 
+      onClick: [
+        "myaccount", 
+        "events", 
+        "mylistings",
+        "payments", 
+        "settings", 
+        "help", 
+        "blogs"
+      ]  
+    },
+    {type: "propertyOwner", colors: "#113170",
+      label: [
+        "My Account", 
+        "Listings",
+        "Payments", 
+        "Settings", 
+        "Help", 
+      ], 
+      onClick: [
+        "myaccount", 
+        "mylistings",
+        "payments", 
+        "settings", 
+        "help", 
+      ]  
+    },
+    {type: "others", colors: "#af1a4d",
+      label: [
+        "My Account",
+        "Favourites",
+        "Payments", 
+        "Settings", 
+        "Help", 
+        "Blogs",
+      ], 
+      onClick: [
+        "myaccount", 
+        "favourites",
+        "payments", 
+        "settings", 
+        "help",
+        "blogs", 
+      ]   
+    }
+  ];
+
+  const accountInfo = accounts.filter(account => accountTypeRetrieved === account.type);
+  const labels = accountInfo[0].label;
+  const onClick = accountInfo[0].onClick;
+  const accountColor = accountInfo[0].colors;
+
   return (
-    <DrawerContentScrollView {...props}>
-      <DrawerItem label="My Account" onPress={() => handleOnClick("myaccount", 1)} focused={active == 1} />
-      <DrawerItem label="Favourites" onPress={() => handleOnClick("favourites", 2)} focused={active == 2} />
-      <DrawerItem label="Settings" onPress={() => handleOnClick("settings", 3)} focused={active == 3} />
-      <DrawerItem label="Help" onPress={() => handleOnClick("help", 4)} focused={active == 4} />
-      <DrawerItem label="Blogs" onPress={() => handleOnClick("blogs", 5)} focused={active == 5} />
-      {true && <DrawerItem label="Testing" onPress={() => handleOnClick("testing", 6)} focused={active == 6} />}
-    </DrawerContentScrollView>
+      <DrawerContentScrollView {...props}>
+          <Image style={{marginTop: "-10%", width: 100, height: 100, alignSelf: "center"}}
+                 source={demoIcon} />
+        <Text style={{
+          marginTop: "-10%",
+          marginBottom: "7.5%", 
+          fontSize: 20, 
+          fontWeight: 700, 
+          flex: 1, 
+          textAlign: "center", 
+          color: accountColor}}>{username}</Text>
+        {labels.map((labelName, index) => (
+          <View style={{borderColor: "#D3D3D3", borderBottomWidth: 2, paddingRight: "5%"}}>
+            <DrawerItem
+              labelStyle={{fontSize: 14}}
+              style={{marginLeft: "12.5%"}}
+              activeTintColor={accountColor}
+              activeBackgroundColor={"FFFFFF"}
+              label={labelName}
+              onPress={() => handleOnClick(onClick[index], index + 1)}
+              focused={active == index + 1}
+            />
+          </View>
+
+        ))}
+        <View style={{borderColor: "#D3D3D3", 
+                      borderBottomWidth: 2, 
+                      paddingRight: "5%"}}>
+          {true && <DrawerItem 
+                      labelStyle={{fontSize: 14}}
+                      style={{marginLeft: "12.5%"}}
+                      activeTintColor={accountColor}
+                      activeBackgroundColor={"FFFFFF"}
+                      label="Testing" 
+                      onPress={() => handleOnClick("testing", labels.length + 1)} 
+                      focused={active == labels.length + 1} 
+          />}
+        </View> 
+
+        <Button
+          textColor={accountColor}
+          style={{
+            marginTop: "85%",
+            textAlign: "center", 
+            color: accountColor
+          }}
+          labelStyle={{
+            fontSize: 18,
+            fontWeight: 600
+          }}
+        >Log Out</Button>
+      
+      </DrawerContentScrollView>
   );
 }

--- a/Components/CustomDrawerContent.jsx
+++ b/Components/CustomDrawerContent.jsx
@@ -8,7 +8,7 @@ import demoIcon from "../assets/images/adaptive-icon.png";
 
 // dummy variables to be replaced by redux API retrieval
 const username = "OliveTree12"
-const accountTypeRetrieved = "propertyOwner"; 
+const accountTypeRetrieved = "tenant"; 
 
 export default function CustomDrawerContent(props) {
   const navigation = useNavigation();
@@ -101,7 +101,7 @@ export default function CustomDrawerContent(props) {
 
   return (
       <DrawerContentScrollView {...props}>
-          <Image style={{marginTop: "-10%", width: 100, height: 100, alignSelf: "center"}}
+        <Image style={{marginTop: "-10%", width: 100, height: 100, alignSelf: "center"}}
                  source={demoIcon} />
         <Text style={{
           marginTop: "-10%",
@@ -134,24 +134,30 @@ export default function CustomDrawerContent(props) {
                       activeTintColor={accountColor}
                       activeBackgroundColor={"FFFFFF"}
                       label="Testing" 
-                      onPress={() => handleOnClick("testing", labels.length + 1)} 
-                      focused={active == labels.length + 1} 
+                      onPress={() => handleOnClick("testing", labels.length)} 
+                      focused={active == labels.length} 
           />}
         </View> 
 
-        <Button
-          textColor={accountColor}
-          style={{
-            marginTop: "85%",
-            textAlign: "center", 
-            color: accountColor
-          }}
-          labelStyle={{
-            fontSize: 18,
-            fontWeight: 600
-          }}
-        >Log Out</Button>
-      
+        <View style={{
+          flex: 1, 
+          justifyContent: "flex-end", 
+          alignItems: "center",
+          marginTop: 12,
+          marginBottom: 36
+          }}>
+          <Button
+            textColor={accountColor}
+            style={{
+              textAlign: "center", 
+              color: accountColor,
+            }}
+            labelStyle={{
+              fontSize: 18,
+              fontWeight: 600
+            }}
+          >Log Out</Button>
+        </View>
       </DrawerContentScrollView>
   );
 }

--- a/Pages/Notifications.jsx
+++ b/Pages/Notifications.jsx
@@ -29,7 +29,7 @@ export default function Notifications() {
     <>
     <View style={{backgroundColor:"#fff",paddingBottom:10,paddingLeft:10,paddingRight:60}}>
     <Searchbar 
-      style={{backgroundColor:"#F1F1F1",borderRadius:99}}
+      style={{backgroundColor:"#F1F1F1",borderRadius:99,marginLeft: "5%"}}
       placeholder="Search"
       onChangeText={(text)=>setText(text)}
       value={text}
@@ -37,13 +37,15 @@ export default function Notifications() {
     </View>
       <View style={landingStyles.container}>
         <ScrollView style={NotificationStyles.notifications}>
+        <View style={{alignSelf: "center"}}>
         {notifications.map(notification => 
         <>
             {notification.text.includes(text)&&<Notification
               text={notification.text}
               linkText={notification.linkText}
               link={notification.link}
-            />}</>)}
+              />}</>)}
+        </View>
         </ScrollView>
       </View>
     </>

--- a/Pages/OnBoarding.jsx
+++ b/Pages/OnBoarding.jsx
@@ -49,7 +49,7 @@ export default function OnBoarding(props) {
 
         <View style={onBoardingStyles.center}>
           <View style={onBoardingStyles.imgWrap}>
-            <Image source={ob1} style={{ width: 315, height: 300, marginTop: 20, }} />
+            <Image source={ob1} style={{ width: 325, height: 315, marginTop: 20, }} />
           </View>
           <Text style={[onBoardingStyles.onboardingHeader, onBoardingStyles.pink]}>
             Coliving 
@@ -108,7 +108,7 @@ export default function OnBoarding(props) {
           </View>
           <View style={onBoardingStyles.center}>
             <View style={onBoardingStyles.imgWrap}>
-              <Image source={ob3} style={{ width: 290, height: 290, marginTop: 20, }} />
+              <Image source={ob3} style={{ width: 300, height: 290, marginTop: 20, }} />
             </View>
             <Text style={[onBoardingStyles.onboardingHeader, onBoardingStyles.pink, {marginBottom: 30,}]}>
               Community

--- a/Pages/Settings.jsx
+++ b/Pages/Settings.jsx
@@ -40,6 +40,7 @@ export default function Settings() {
             </View>
             <Text style={settingStyles.subHeader}> Settings</Text>
           </View>
+          
           <Text style={settingStyles.title}>Push Notifications</Text>
             
           <View style={settingStyles.entryView}>

--- a/Pages/Settings.jsx
+++ b/Pages/Settings.jsx
@@ -33,41 +33,45 @@ export default function Settings() {
   return (
     <>
       <View style={landingStyles.container}>
-        <View style={{ width: "125%", paddingHorizontal: 80, paddingVertical: 175, backgroundColor: "white" }}>
-          <Text style={settingStyles.subHeader}>Account Settings</Text>
-          <Text style={settingStyles.border}>   </Text>
+        <View style={{ width: "115%", paddingHorizontal: 100, paddingVertical: 300, backgroundColor: "white" }}>
+          <View style={{ flexDirection: "row", marginTop: "-70%" }}>
+            <View style={settingStyles.borderView}>
+              <Text style={settingStyles.subHeader}>Account</Text>
+            </View>
+            <Text style={settingStyles.subHeader}> Settings</Text>
+          </View>
           <Text style={settingStyles.title}>Push Notifications</Text>
             
           <View style={settingStyles.entryView}>
             <Text style={settingStyles.entryText}>{notifications[0].title}</Text>
-            <Switch color={"#af1a4d"} style={settingStyles.switch} value={notifications[0].toggleStatus} onValueChange={() => toggleSwitch(0)}></Switch>
+            <Switch color={"#f83e7d"} style={settingStyles.switch} value={notifications[0].toggleStatus} onValueChange={() => toggleSwitch(0)}></Switch>
           </View>
           
           <View style={settingStyles.entryView}>
             <Text style={settingStyles.entryText}>{notifications[1].title}</Text>
-            <Switch color={"#af1a4d"} style={settingStyles.switch} value={notifications[1].toggleStatus} onValueChange={() => toggleSwitch(1)}></Switch>
+            <Switch color={"#f83e7d"} style={settingStyles.switch} value={notifications[1].toggleStatus} onValueChange={() => toggleSwitch(1)}></Switch>
           </View>            
 
           <View style={settingStyles.entryView}>
             <Text style={settingStyles.entryText}>{notifications[2].title}</Text>
-            <Switch color={"#af1a4d"} style={settingStyles.switch} value={notifications[2].toggleStatus} onValueChange={() => toggleSwitch(2)}></Switch>
+            <Switch color={"#f83e7d"} style={settingStyles.switch} value={notifications[2].toggleStatus} onValueChange={() => toggleSwitch(2)}></Switch>
           </View>  
 
           <View style={settingStyles.entryView}>
             <Text style={settingStyles.entryText}>{notifications[3].title}</Text>
-            <Switch color={"#af1a4d"} style={settingStyles.switch} value={notifications[3].toggleStatus} onValueChange={() => toggleSwitch(3)}></Switch>
+            <Switch color={"#f83e7d"} style={settingStyles.switch} value={notifications[3].toggleStatus} onValueChange={() => toggleSwitch(3)}></Switch>
           </View>     
 
           <Text style={settingStyles.title}>Privacy and Security</Text>      
 
           <View style={settingStyles.entryView}>
             <Text style={settingStyles.entryText}>{notifications[4].title}</Text>
-            <Switch color={"#af1a4d"} style={settingStyles.switch} value={notifications[4].toggleStatus} onValueChange={() => toggleSwitch(4)}></Switch>
+            <Switch color={"#f83e7d"} style={settingStyles.switch} value={notifications[4].toggleStatus} onValueChange={() => toggleSwitch(4)}></Switch>
           </View>   
 
           <View style={settingStyles.entryView}>
             <Text style={settingStyles.entryText}>{notifications[5].title}</Text>
-            <Switch color={"#af1a4d"} style={settingStyles.switch} value={notifications[5].toggleStatus} onValueChange={() => toggleSwitch(5)}></Switch>
+            <Switch color={"#f83e7d"} style={settingStyles.switch} value={notifications[5].toggleStatus} onValueChange={() => toggleSwitch(5)}></Switch>
           </View>   
 
         </View>

--- a/Pages/pageStyles/settingStyles.js
+++ b/Pages/pageStyles/settingStyles.js
@@ -3,18 +3,15 @@ import theme from "./theme";
 
 export default StyleSheet.create({
   subHeader: {
-    marginTop: "-40%",
     fontWeight: 600,
     fontSize: 22,
   },
 
-  border: {
+  borderView: {
     borderBottomWidth: 3,
-    borderBottomColor: "#af1a4d", 
-    width: 75,
-    marginTop: -20,
+    borderBottomColor: "#f83e7d", 
     marginBottom: 20,
-    marginLeft: 5
+    marginLeft: 5,
   },
 
   title: {
@@ -35,12 +32,12 @@ export default StyleSheet.create({
     fontWeight: 500,
     fontSize: 12,
     fontWeight: 500,
-    paddingVertical: "2.5%"
+    paddingVertical: "5.5%"
   },
 
   switch: {
     marginLeft: 30,
-    transform: [{ scaleX: 1.5 }, { scaleY: 1.5 }],
+    transform: [{ scaleX: 1.25 }, { scaleY: 1.25 }],
     color: "#f83e7d"
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,8 @@
         "react-native-screens": "~3.20.0",
         "react-native-swiper": "^1.6.0",
         "react-native-vector-icons": "^9.2.0",
-        "react-native-web": "~0.18.10"
+        "react-native-web": "~0.18.10",
+        "yarn": "^1.22.19"
       },
       "devDependencies": {
         "@babel/core": "^7.20.0"
@@ -17741,6 +17742,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/yarn": {
+      "version": "1.22.19",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+      "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ==",
+      "hasInstallScript": true,
+      "bin": {
+        "yarn": "bin/yarn.js",
+        "yarnpkg": "bin/yarn.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -31043,6 +31057,11 @@
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         }
       }
+    },
+    "yarn": {
+      "version": "1.22.19",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.22.19.tgz",
+      "integrity": "sha512-/0V5q0WbslqnwP91tirOvldvYISzaqhClxzyUKXYxs07yUILIs5jx/k6CFe8bvKSkds5w+eiOqta39Wk3WxdcQ=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "react-native-screens": "~3.20.0",
     "react-native-swiper": "^1.6.0",
     "react-native-vector-icons": "^9.2.0",
-    "react-native-web": "~0.18.10"
+    "react-native-web": "~0.18.10",
+    "yarn": "^1.22.19"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0"


### PR DESCRIPTION
**Please merge this after merging issue-26, as this branches from after issue-26**

Fixed the side paneling, styling, etc and tested it for both platforms.
- const username is the variable that holds a dummy username until API values are passed in
- const accountTypeRetrieved is the variable that holds a dummy account type (currently set to "tenant", but can also be "propertyOwnerFemale", "propertyOwner", and "others") until the API values are passed in
- "demoIcon" is being used as the dummy image until the API values are passed in
- A log out button is created and placed at the end of the sidebar, but no onPress functionality has been implemented for it yet
- The "testing" drawerItem has been left in as no instructions regarding it was made in the issue

As you can see from the different images below, both contain different colors and entries as represented by their account type (first one is for tenant, second one is for propertyOwnerFemale).

<img width="325" alt="image" src="https://user-images.githubusercontent.com/59082260/236296665-ae829b93-6132-4235-9bc9-dc9bd3d27415.png">

<img width="316" alt="image" src="https://user-images.githubusercontent.com/59082260/236297905-f6a7cda1-e251-408a-bd74-c2983de447e6.png">
